### PR TITLE
Fixes for newer versions of jsoncpp

### DIFF
--- a/cmd/node/ArrasNode.cc
+++ b/cmd/node/ArrasNode.cc
@@ -687,7 +687,7 @@ ArrasNode::updateTags(api::ObjectConstRef tags)
         api::Object current = mNodeInfo["tags"];
         for (api::ObjectConstIterator it = tags.begin();
              it != tags.end(); ++it) {
-            current[it.memberName()] = *it;
+            current[it.name()] = *it;
         }
         std::string msg;
         if (!validateTags(current, msg)) 
@@ -741,7 +741,7 @@ ArrasNode::updateTagsProc(api::Object tags)
     api::Object current = mNodeInfo["tags"];
     for (api::ObjectIterator it = tags.begin();
          it != tags.end(); ++it) {
-        current[it.memberName()] = *it;
+        current[it.name()] = *it;
     }
 
     std::string msg;

--- a/cmd/node/ArrasNode.cc
+++ b/cmd/node/ArrasNode.cc
@@ -685,7 +685,7 @@ ArrasNode::updateTags(api::ObjectConstRef tags)
 
         // verify tags        
         api::Object current = mNodeInfo["tags"];
-        for (api::ObjectIterator it = tags.begin();
+        for (api::ObjectConstIterator it = tags.begin();
              it != tags.end(); ++it) {
             current[it.memberName()] = *it;
         }
@@ -716,7 +716,7 @@ ArrasNode::deleteTags(api::ObjectConstRef tags)
 
         // verify tags
         api::Object current = mNodeInfo["tags"];
-        for (api::ObjectIterator it = tags.begin();
+        for (api::ObjectConstIterator it = tags.begin();
              it != tags.end(); ++it) {
             if ((*it).isString() && current.isMember((*it).asString())) {
                 current.removeMember((*it).asString());

--- a/cmd/node/router/SessionNodeMap.cc
+++ b/cmd/node/router/SessionNodeMap.cc
@@ -21,7 +21,7 @@ SessionNodeMap::SessionNodeMap(api::ObjectConstRef aRoutingData)
         info.port = static_cast<unsigned short>((*nodeIt)["tcp"].asInt());
    
 
-        api::UUID nodeId(nodeIt.memberName());// memberName() is DEPRECATED in later jsoncpp versions
+        api::UUID nodeId(nodeIt.name());
         info.nodeId = nodeId;
         mMap[nodeId] = info;
 
@@ -45,7 +45,7 @@ SessionNodeMap::update(api::ObjectConstRef aRoutingData)
     api::ObjectConstRef nodes = aRoutingData["nodes"];
     for (api::ObjectConstIterator nodeIt = nodes.begin();
          nodeIt != nodes.end(); ++nodeIt) {
-        api::UUID nodeId(nodeIt.memberName());// memberName() is DEPRECATED in later jsoncpp versions
+        api::UUID nodeId(nodeIt.name());
         if (mMap.count(nodeId) == 0) {
             NodeInfo info;
             info.hostname = (*nodeIt)["host"].asString();

--- a/lib/session/Computation.cc
+++ b/lib/session/Computation.cc
@@ -232,7 +232,7 @@ void Computation::getPerformanceStats(api::ObjectRef obj)
 {
     std::lock_guard<std::mutex> lock(mStatsMutex);
   
-    obj["memoryUsageBytesMax"] = mMemoryUsageBytesMax;
+    obj["memoryUsageBytesMax"] = (Json::UInt64)mMemoryUsageBytesMax;
     obj["memoryUsageBytesCurrent"] = (Json::UInt64)mLastHeartbeat->mMemoryUsageBytesCurrent;
 
     obj["cpuUsage5Secs"] = mLastHeartbeat->mCpuUsage5SecsCurrent;

--- a/lib/session/SessionConfig.cc
+++ b/lib/session/SessionConfig.cc
@@ -80,7 +80,7 @@ SessionConfig::SessionConfig(api::ObjectConstRef desc,
     for (api::ObjectConstIterator cIt = comps.begin();
          cIt != comps.end(); ++cIt) {
 
-        std::string compName = cIt.memberName();
+        std::string compName = cIt.name();
         api::ObjectConstRef info = *cIt;
 
         if (!info.isObject() || 


### PR DESCRIPTION
Also changed out uses of memberName to name since it was deprecated.